### PR TITLE
Feature/refactoring

### DIFF
--- a/backend/app/controllers/api/v1/kids_controller.rb
+++ b/backend/app/controllers/api/v1/kids_controller.rb
@@ -106,7 +106,7 @@ module Api
         kid.image = params[:image]
         if kid.save!
           render json: {
-            status: "ok",
+            status: 200,
             message: "画像を登録しました",
             severity: "success"
           }

--- a/backend/app/controllers/api/v1/notebooks_controller.rb
+++ b/backend/app/controllers/api/v1/notebooks_controller.rb
@@ -6,7 +6,7 @@ module Api
         notebook = kid.notebooks.build(notebook_params)
         if notebook.save!
           render json: {
-            status: "ok",
+            status: 200,
             message: "登録が完了しました"
           }
         else
@@ -37,7 +37,9 @@ module Api
         kid = Kid.find(params[:kid_id])
         date = params[:date]
         new_date = date.slice(0..9)
-        notebook = kid.notebooks.find_by(date: new_date)
+        notebooks = kid.notebooks.where(date: new_date)
+        notebook = notebooks.last
+        # notebook = kid.notebooks.find_by(date: new_date)
         if notebook.present?
           render json: notebook
         else

--- a/backend/app/controllers/api/v1/notebooks_controller.rb
+++ b/backend/app/controllers/api/v1/notebooks_controller.rb
@@ -22,7 +22,7 @@ module Api
         notebook = kid.notebooks.find_by(id: params[:id])
         if notebook.update!(notebook_params)
           render json: {
-            status: "ok",
+            status: 200,
             message: "更新が完了しました"
           }
         else
@@ -39,7 +39,6 @@ module Api
         new_date = date.slice(0..9)
         notebooks = kid.notebooks.where(date: new_date)
         notebook = notebooks.last
-        # notebook = kid.notebooks.find_by(date: new_date)
         if notebook.present?
           render json: notebook
         else

--- a/backend/app/controllers/api/v1/posts_controller.rb
+++ b/backend/app/controllers/api/v1/posts_controller.rb
@@ -10,7 +10,7 @@ module Api
         if post.save!
           posts = Post.all
           render json: {
-            status: "ok",
+            status: 200,
             message: "投稿が完了しました！",
             posts: posts
           }

--- a/backend/app/controllers/api/v1/users_controller.rb
+++ b/backend/app/controllers/api/v1/users_controller.rb
@@ -14,7 +14,7 @@ module Api
         user = User.find(params[:id])
         if user.update!(user_params)
           render json: {
-            status: "ok",
+            status: 200,
             message: "更新が完了しました",
             id: user.id,
             email: user.email,
@@ -54,7 +54,7 @@ module Api
         user.image = params[:image]
         if user.save
           render json: {
-            status: "ok",
+            status: 200,
             message: "画像を登録しました",
             severity: "success"
           }

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -14,7 +14,7 @@ paths:
       parameters:
         - name: daycare_id
           in: path
-          description: 特定の子供の名前と年齢を取得
+          description: 保育園のID
           required: true
           type: integer
           format: int64
@@ -80,7 +80,7 @@ paths:
           format: int64
         - name: id
           in: path
-          description: 子供のID
+          description: ユーザーのID
           required: true
           type: integer
           format: int64
@@ -105,15 +105,15 @@ paths:
         400:
           description: "投稿内容に不備"
           schema:
-            $ref: "#/definitions/404Error"
-  /api/v1/daycares/:daycare_id/posts:
+            $ref: "#/definitions/400InputError"
+  /api/v1/daycares/:id/posts:
     get:
       tags:
         - "posts"
       summary: "ある保育園の全ての投稿取得"
       description: ""
       parameters:
-        - name: daycare_id
+        - name: id
           in: path
           description: 保育園のID
           required: true
@@ -136,7 +136,7 @@ paths:
       summary: "ある保育園の子供のデータを全て取得"
       description: ""
       parameters:
-        - name: daycare_id
+        - name: id
           in: path
           description: 保育園のID
           required: true
@@ -341,6 +341,12 @@ paths:
       summary: "連絡帳更新"
       description: ""
       parameters:
+        - name: id
+          in: path
+          description: 連絡帳のID
+          required: true
+          type: integer
+          format: int64
         - in: body
           name: "body"
           description: "連絡帳の入力値"
@@ -352,7 +358,7 @@ paths:
           description: "成功時のレスポンス"
           schema:
             $ref: "#/definitions/BasicResponse"
-        400:
+        422:
           description: "失敗時のレスポンス"
           schema:
             $ref: "#/definitions/BasicResponse"

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -58,7 +58,7 @@ export const Home: React.FC = () => {
   const [telephoneNumber, setTelephoneNumber] = useState('');
   const [isParentModalOpen, setIsParentModalOpen] = useState(false);
 
-  const [image, setImage] = useState<any>(null);
+  const [image, setImage] = useState<string | Blob>('');
   const [message, setMassage] = useState('');
   const [disabled, setDisabled] = useState(true);
   const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
@@ -129,7 +129,7 @@ export const Home: React.FC = () => {
       })
       .then((res) => {
         setMassage(res.data.message);
-        setImage(null);
+        setImage('');
         setDisabled(true);
         setIsKidModalOpen(false);
         setSeverity(res.data.severity);
@@ -170,7 +170,7 @@ export const Home: React.FC = () => {
       })
       .finally(() => {
         setLoading(false);
-        setImage(null);
+        setImage('');
         setIsSnackbarOpen(true);
       });
   };
@@ -225,7 +225,7 @@ export const Home: React.FC = () => {
       .then((res) => {
         setMassage(res.data.message);
         setSeverity(res.data.severity);
-        setImage(null);
+        setImage('');
         setDisabled(true);
         setIsParentModalOpen(false);
       })
@@ -295,7 +295,7 @@ export const Home: React.FC = () => {
   );
 
   const resizeFile = (file: File) =>
-    new Promise((resolve) => {
+    new Promise((resolve: (value: string | Blob | File) => void) => {
       Resizer.imageFileResizer(
         file,
         300,
@@ -303,7 +303,7 @@ export const Home: React.FC = () => {
         'JPEG',
         100,
         0,
-        (uri) => {
+        (uri:any) => {
           resolve(uri);
         },
         'base64',


### PR DESCRIPTION
[update][#86]urlをany型に変更
にてurlをany型にしたのですがこのanyをしっかりと定義したいです。

urlの型がimageFileResizerメソッドによって```string | Blob | File | ProgressEvent<FileReader>```に固定されてしまいます。これを```string | Blob | File ```に変更(上書き)したいです。

```url: string | Blob | File```というように型を指定すると
```
型 '(uri: string | Blob | File) => void' の引数を型 '(value: string | Blob | File | ProgressEvent<FileReader>) => void' のパラメーターに割り当てることはできません。
  パラメーター 'uri' および 'value' は型に互換性がありません。
    型 'string | Blob | File | ProgressEvent<FileReader>' を型 'string | Blob | File' に割り当てることはできません。
      型 'ProgressEvent<FileReader>' を型 'string | Blob | File' に割り当てることはできません。
        型 'ProgressEvent<FileReader>' には 型 'File' からの次のプロパティがありません: lastModified, name, size, arrayBuffer、3 など。
```
というエラーになります。 今回のimageFileResizerメソッドのように、メソッドによって既に型が決められてしまっている場合どのように型を上書きするべきでしょうか？